### PR TITLE
fix: スタックトレースを出し入れできるようにする。

### DIFF
--- a/src/main/java/com/example/controller/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/controller/error/GlobalExceptionHandler.java
@@ -1,0 +1,56 @@
+package com.example.controller.error;
+
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.ui.Model;
+import org.springframework.core.env.Environment;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+	@Autowired
+	private ErrorAttributes errorAttributes;
+
+	@Autowired
+	private Environment environment;
+
+	@ExceptionHandler(NotFoundException.class) // カスタム例外クラスを作成して404エラーをハンドリング
+	public String handleNotFound() {
+		return "error/404"; // 404エラーページのパスを返す
+	}
+
+	@ExceptionHandler(Exception.class)
+	public String handle500Error(Model model, WebRequest request) {
+		// server.error.include-stacktrace プロパティの値を確認
+		String includeStacktrace = environment.getProperty("server.error.include-stacktrace");
+
+		// スタックトレースを取得
+		if ("always".equalsIgnoreCase(includeStacktrace)) {
+			Throwable error = errorAttributes.getError(request);
+			StringWriter sw = new StringWriter();
+			PrintWriter pw = new PrintWriter(sw);
+			error.printStackTrace(pw);
+			String stackTrace = sw.toString();
+
+			// スタックトレースをテンプレートに渡す
+			model.addAttribute("stackTrace", stackTrace);
+		}
+
+		return "error/500"; // 500エラーページのパスを返す
+	}
+
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	public static class NotFoundException extends RuntimeException {
+		public NotFoundException() {
+			super("リソースが見つかりません。");
+		}
+	}
+}

--- a/src/main/resources/templates/error/400.html
+++ b/src/main/resources/templates/error/400.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="utf-8" />
+    <title>Error</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        text-align: center;
+        font-family: sans-serif;
+      }
+
+      h1,
+      a {
+        margin: 0;
+        padding: 0;
+        text-decoration: none;
+      }
+
+      .section {
+        padding: 4rem 2rem;
+      }
+
+      .section .error {
+        font-size: 150px;
+        color: #008b62;
+        text-shadow: 1px 1px 1px #00593e, 2px 2px 1px #00593e,
+          3px 3px 1px #00593e, 4px 4px 1px #00593e, 5px 5px 1px #00593e,
+          6px 6px 1px #00593e, 7px 7px 1px #00593e, 8px 8px 1px #00593e,
+          25px 25px 8px rgba(0, 0, 0, 0.2);
+      }
+
+      .page {
+        margin: 2rem 0;
+        font-size: 20px;
+        font-weight: 600;
+        color: #444;
+      }
+
+      .back-home {
+        display: inline-block;
+        border: 2px solid #222;
+        color: #222;
+        text-transform: uppercase;
+        font-weight: 600;
+        padding: 0.75rem 1rem 0.6rem;
+        transition: all 0.2s linear;
+        box-shadow: 0 3px 8px rgba(0, 0, 0, 0.3);
+      }
+      .back-home:hover {
+        background: #222;
+        color: #ddd;
+      }
+      .stack-trace {
+            font-size: 14px;
+            font-weight: normal;
+            text-align: left;
+        }
+    </style>
+  </head>
+  <body>
+    <div class="section">
+      <h1 class="error">400</h1>
+      <div class="page">このリンクに問題があります</div>
+      <a class="back-home" href="/">TOPへ戻る</a>
+      <div th:if="${trace}" class="stack-trace" th:utext="${trace}"></div>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/templates/error/500.html
+++ b/src/main/resources/templates/error/500.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="utf-8" />
+    <title>Error</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        text-align: center;
+        font-family: sans-serif;
+      }
+
+      h1,
+      a {
+        margin: 0;
+        padding: 0;
+        text-decoration: none;
+      }
+
+      .section {
+        padding: 4rem 2rem;
+      }
+
+      .section .error {
+        font-size: 150px;
+        color: #008b62;
+        text-shadow: 1px 1px 1px #00593e, 2px 2px 1px #00593e,
+          3px 3px 1px #00593e, 4px 4px 1px #00593e, 5px 5px 1px #00593e,
+          6px 6px 1px #00593e, 7px 7px 1px #00593e, 8px 8px 1px #00593e,
+          25px 25px 8px rgba(0, 0, 0, 0.2);
+      }
+
+      .page {
+        margin: 2rem 0;
+        font-size: 20px;
+        font-weight: 600;
+        color: #444;
+      }
+
+      .back-home {
+        display: inline-block;
+        border: 2px solid #222;
+        color: #222;
+        text-transform: uppercase;
+        font-weight: 600;
+        padding: 0.75rem 1rem 0.6rem;
+        transition: all 0.2s linear;
+        box-shadow: 0 3px 8px rgba(0, 0, 0, 0.3);
+      }
+      .back-home:hover {
+        background: #222;
+        color: #ddd;
+      }
+      .stack-trace {
+            font-size: 14px;
+            font-weight: normal;
+            text-align: left;
+        }
+    </style>
+  </head>
+  <body>
+    <div class="section">
+      <h1 class="error">500</h1>
+      <div class="page">アクセスしようとしたページは表示できませんでした</div>
+      <a class="back-home" href="/">TOPへ戻る</a>
+      <div th:if="${stackTrace}" class="stack-trace" th:utext="${stackTrace}"></div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
- [ ] /not-foundで404を表示
- [ ] 「server.error.include-stacktrace=never」にて、「/apps/not-found」で500を表示スタックトレースが非表示になっている
- [ ] 「server.error.include-stacktrace=alweys」にて、「/apps/not-found」で500を表示スタックトレースが表示されている